### PR TITLE
update to effective_from_date

### DIFF
--- a/pymdoccbor/mso/issuer.py
+++ b/pymdoccbor/mso/issuer.py
@@ -92,7 +92,7 @@ class MsoIssuer(MsoX509Fabric):
 
                 _value_cbortag = settings.CBORTAGS_ATTR_MAP.get(k, None)
 
-                if _value_cbortag:
+                if _value_cbortag is not None:
                     v = cbor2.CBORTag(_value_cbortag, value=v)
                     # print("\n-----\n K,V ", k, "\n", v)
 

--- a/pymdoccbor/settings.py
+++ b/pymdoccbor/settings.py
@@ -44,4 +44,5 @@ CBORTAGS_ATTR_MAP = {
     "expiry_date": 1004,
     "issue_date": 1004,
     "issuance_date": 1004,
+    "effective_from_date": 0,
 }


### PR DESCRIPTION
- Updated effective_from_date to be tagged as cbor tag 0 (Standard date/time string)
- Fixed a bug where tag 0 was skipped